### PR TITLE
utils.formatText - Remoção da sanitização

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,7 +92,6 @@ const regexPicture = (exp, picture) => {
  * acentuação gráfica (ex.: “Á”, “É”, “Ê”, etc) e os campos não utiliza dos deverão ser preenchidos com brancos.
  * */
 const formatText = function (value, size) {
-  value = value.replace(/[^a-zA-Z ]/g, "")
   while (value.length < size) {
     value = value + ' ';
   }


### PR DESCRIPTION
Exemplo: Se no 'detalhe_segmento_q' informar: logradouro = 'EST AFONSO CORREA, 285', a virgula e os numeros são sanitizados.